### PR TITLE
Fix/join project multiple times

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -41,9 +41,6 @@ pub enum ServerRequest {
         segments: Vec<Segment>,
     },
     #[serde(rename_all = "camelCase")]
-    ChangeProjectName {
-        new_name: ProjectId,
-    },
     NewProject {
         #[serde(flatten)]
         project: Project,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -65,7 +65,7 @@ pub fn preview(
     let id = PreviewId::from_project_sentence(videos, phonems);
     let p = id.path();
     if !p.exists() {
-        render_phonems(videos, &phonems, &p, true)
+        render_phonems(videos, phonems, &p, true)
     } else {
         Ok(())
     }
@@ -79,7 +79,7 @@ pub fn render(
     let id = PreviewId::from_project_sentence(videos, phonems);
     let p = id.render_path();
     if !p.exists() {
-        render_phonems(videos, &phonems, &p, false)
+        render_phonems(videos, phonems, &p, false)
     } else {
         Ok(())
     }

--- a/src/sm_actor.rs
+++ b/src/sm_actor.rs
@@ -251,19 +251,18 @@ impl SmActor {
         project_name: ProjectId,
         user: ClientId,
     ) -> Result<(ServerRequest, ServerRequest, ServerRequest), ServerError> {
-        let users = &self.editing_sessions[&project_name];
-        if users.contains(&user) {
-            return Err(ServerError::UserAlreadyJoinedProject);
-        }
-
         let users = self
             .editing_sessions
             .get_mut(&project_name)
             .expect("Inconsistent sessions/data");
+
+        if !users.contains(&user) {
+            users.insert(user);
+        }
+
         let request_joined_users = ServerRequest::JoinedUsers {
             users: users.iter().copied().collect(),
         };
-        users.insert(user);
 
         let Project {
             seed,

--- a/src/sm_actor.rs
+++ b/src/sm_actor.rs
@@ -424,7 +424,7 @@ impl Handler<Disconnect> for SmActor {
             .iter()
             .fold(HashSet::new(), |acc, hs| acc.union(hs).cloned().collect())
             .iter()
-            .map(|id| self.sessions[&id].clone())
+            .map(|id| self.sessions[id].clone())
             .collect();
 
         self.sessions.remove(&msg.id);


### PR DESCRIPTION
Allows a user to join a project when they are already registered in it.

This updates the `front` submodule to its latest revision.

Also, fixes compilation errors.